### PR TITLE
refactor: SDK consolidation, docs workflow, README clarifications

### DIFF
--- a/.changeset/docs-and-readme-clarifications.md
+++ b/.changeset/docs-and-readme-clarifications.md
@@ -1,0 +1,10 @@
+---
+"@sbtools/core": minor
+"@sbtools/sdk": minor
+---
+
+- SDK: Add `sanitizeContainerPrefix`, `deriveContainerPrefix`, `extractSupabaseKeys`, `sanitizeSlug`, `sanitizeIdentifier`; add compose/container/fs-utils tests
+- Core: Remove `docs` command from core (now provided by plugin-docs-server); `stop` no longer stops docs compose stack; use SDK container/compose utilities
+- plugin-docs-server: Add `docs` command with subcommands (swagger, redoc, atlas, schemaspy, all, stop); per-subcommand preflight
+- Plugins: Use shared SDK utilities; improved error handling (SbtError with tips); remove redundant root index.ts
+- Docs: Fix extractSupabaseKeys typo; clarify start/stop/restart operate on main stack; document plugin-docs-server requirement for docs commands

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Thumbs.db
 *.tgz
 docs/.vitepress/cache
 docs/.vitepress/dist
+.cursor/plans/

--- a/README.md
+++ b/README.md
@@ -27,19 +27,23 @@ npx sbt generate-erd
 
 | Command | Description |
 |---------|-------------|
-| `start` | Start all Supabase Docker services |
-| `stop` | Stop all services |
-| `restart` | Restart all services |
+| `start` | Start Supabase stack (DB, API, etc.) |
+| `stop` | Stop main Supabase stack (run `sbt docs stop` for documentation containers; requires plugin-docs-server) |
+| `restart` | Restart main Supabase stack |
 | `status` | Show service URLs, keys, connection info |
 | `migrate` | Apply SQL migrations from `supabase/migrations/` |
 | `snapshot` | Export DB objects to filesystem |
 | `generate-types` | Generate TypeScript types from the DB schema |
 | `generate-erd` | Generate Mermaid ERD diagrams per table |
-| `generate-atlas` | Generate Backend Atlas HTML visualization |
+| `generate-atlas` | Generate Backend Atlas data (JSON) |
 | `test` | Run SQL tests against the running DB |
 | `test --mem` | Run SQL tests in-memory with PGlite |
-| `docs` | Auto-generate snapshot/atlas/ERD + start Swagger UI, ReDoc |
-| `docs stop` | Stop documentation containers |
+| `docs` | Start all documentation services (Swagger, ReDoc, Atlas, SchemaSpy) — requires plugin-docs-server |
+| `docs swagger` | Start Swagger UI only |
+| `docs redoc` | Start ReDoc only |
+| `docs atlas` | Start Backend Atlas only |
+| `docs schemaspy` | Start SchemaSpy only |
+| `docs stop` | Stop all documentation containers |
 | `init` | Generate `supabase-tools.config.json` with defaults |
 
 All commands: `npx sbt <command>`
@@ -75,6 +79,27 @@ Full docs: [docs site](https://bazokhan.github.io/supabase-tools/) (or run `npm 
 | plugin-frontend-usage | `@sbtools/plugin-frontend-usage` | Frontend SDK usage scanner |
 | plugin-logs | `@sbtools/plugin-logs` | Docker logs, pg_stat_statements |
 | plugin-scaffold | `@sbtools/plugin-scaffold` | Scaffold new plugins |
+
+## Docs Workflow
+
+Requires `plugin-docs-server` in your config. Each docs service can run independently with its own preflight:
+
+| To run only... | Prerequisites | Command |
+|----------------|---------------|---------|
+| Swagger UI | Docker, openapi-spec (auto-fetched or placeholder) | `sbt docs swagger` |
+| ReDoc | Same as Swagger | `sbt docs redoc` |
+| Backend Atlas | `sbt generate-atlas` + `sbt atlas-html` | `sbt docs atlas` |
+| SchemaSpy | Docker + DB running | `sbt docs schemaspy` |
+| All services | All of the above | `sbt docs all` or `sbt docs` |
+
+Full sequence for all docs:
+
+1. `sbt start`
+2. `sbt snapshot`
+3. `sbt generate-atlas`
+4. `sbt atlas-html`
+5. `sbt generate-erd`
+6. `sbt docs all`
 
 ## License
 

--- a/docs/sdk/index.md
+++ b/docs/sdk/index.md
@@ -1,5 +1,5 @@
 ---
-description: SDK types, PluginContext, UI utilities, error classes, and helpers for building plugins.
+description: SDK types, PluginContext, UI utilities, error classes, container/compose utils, and helpers for building plugins.
 ---
 
 # SDK API Reference
@@ -49,16 +49,52 @@ ui.table([["a", "b"], ["1", "2"]], 2);
 
 Use `handleError(err)` for consistent error output.
 
-## Helpers
+## Filesystem Utilities
 
-- `ensureDir(path)` — Create directory
+- `ensureDir(path)` — Create directory recursively
 - `readText(path)` — Read file as UTF-8
 - `writeFileInDir(dir, filename, content)` — Write file in directory
-- `safeName(str)` — Sanitize for identifiers
-- `safeFileName(str)` — Sanitize for filenames
-- `hasFlag(args, name)` — Check for CLI flags
+- `safeName(str)` — Replace non-word chars with underscore (for filenames)
+- `safeFileName(baseName, maxLength?)` — Truncate long filenames with hash
+- `sanitizeSlug(str)` — Hyphenated slug (e.g. plugin names, directory names)
+- `sanitizeIdentifier(str)` — Alphanumeric + underscore (e.g. Mermaid node IDs)
+
+## Container Utilities
+
+For Docker Compose project naming (used by core and plugins that interact with containers):
+
+- `sanitizeContainerPrefix(projectName)` — Sanitize raw project name into valid Docker prefix
+- `deriveContainerPrefix(projectRoot)` — Read `supabase-tools.config.json` for `project.name`, fallback to basename, return sanitized prefix
+
+```ts
+import { deriveContainerPrefix, sanitizeContainerPrefix } from "@sbtools/sdk";
+
+const prefix = deriveContainerPrefix(ctx.projectRoot);
+const container = `${prefix}-supabase-db`;
+
+// Or when you already have the name:
+const prefix2 = sanitizeContainerPrefix(config.project.name);
+```
+
+## Compose Utilities
+
+Extract values from Docker Compose YAML files:
+
+- `extractComposeKey(composePath, patterns)` — First matching regex capture
+- `extractSupabaseKeys(composePath)` — Returns `{ anonKey, serviceKey }` in one read (see `SupabaseKeys` type)
+
+```ts
+import { extractComposeKey, extractSupabaseKeys } from "@sbtools/sdk";
+
+const { anonKey, serviceKey } = extractSupabaseKeys(path.join(ctx.toolsDir, "docker-compose.db.yml"));
+const jwtSecret = extractComposeKey(composePath, [/JWT_SECRET:\s*([^\s]+)/]);
+```
+
+## CLI Utilities
+
+- `hasFlag(args, ...names)` — Check for CLI flags (e.g. `--help`, `-h`)
 - `getArg(args, name)` — Get CLI argument value
-- `extractComposeKey(path, regexes)` — Extract keys from docker-compose
+- `openFile(path)` — Open file in default editor
 
 ## Building Plugins
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "npm run build -w packages/sdk && npm run build --workspaces",
     "clean": "npm run clean --workspaces",
     "release": "npm run build && changeset publish",
-    "test": "vitest run --config packages/core/vitest.config.ts && vitest run --config packages/plugin-erd/vitest.config.ts && vitest run --config packages/plugin-typegen/vitest.config.ts && vitest run --config packages/plugin-db-test/vitest.config.ts && vitest run --config packages/plugin-depgraph/vitest.config.ts",
+    "test": "vitest run --config packages/sdk/vitest.config.ts && vitest run --config packages/core/vitest.config.ts && vitest run --config packages/plugin-erd/vitest.config.ts && vitest run --config packages/plugin-typegen/vitest.config.ts && vitest run --config packages/plugin-db-test/vitest.config.ts && vitest run --config packages/plugin-depgraph/vitest.config.ts",
     "test:watch": "vitest --config packages/core/vitest.config.ts",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -37,6 +37,15 @@ Then `npm run start`, etc.
 - Snapshot pipeline (export DB schema)
 - Pre-flight checks
 
+## Dependencies
+
+| Type | Requirement |
+|------|-------------|
+| Docker | Must be running for `start`, `stop`, `restart`, `status`, `snapshot`, `migrate` |
+| Compose files | `docker-compose.db.yml` in toolsDir |
+| Migrations dir | `config.paths.migrations` must exist for `migrate` |
+| Snapshot meta | `supabase/current/_meta/snapshot.json` must exist for `generate-atlas` (run `sbt snapshot` first) |
+
 ## Plugins
 
 Add plugins via config:

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -2,8 +2,7 @@
 import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { ui, SbtError, handleError } from "@sbtools/sdk";
-import type { SbtPluginCommand } from "@sbtools/sdk";
+import { ui, SbtError, handleError, sanitizeContainerPrefix } from "@sbtools/sdk";
 import { config, resolve } from "./config.js";
 import { loadPlugins, buildPluginContext } from "./plugin-loader.js";
 import { preflight } from "./preflight.js";
@@ -17,7 +16,6 @@ const command = process.argv[2];
 const args = process.argv.slice(3);
 
 const COMPOSE_DB = path.join(config.toolsDir, "docker-compose.db.yml");
-const COMPOSE_DOCS = path.join(config.toolsDir, "docker-compose.api-docs.yml");
 const SBT_ENV_FILE = path.join(config.sbtDataDir, ".env");
 
 function run(cmd: string): void {
@@ -45,8 +43,7 @@ function ensureProjectDirs(): void {
   fs.mkdirSync(docsAbsolute, { recursive: true });
   fs.mkdirSync(config.sbtDataDir, { recursive: true });
   fs.mkdirSync(path.join(config.sbtDataDir, "schemaspy-out"), { recursive: true });
-  const containerPrefix = config.project.name
-    .replace(/[^a-zA-Z0-9-]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "").toLowerCase() || "sbt";
+  const containerPrefix = sanitizeContainerPrefix(config.project.name);
   const functionsAbs = path.resolve(config.projectRoot, config.paths.functions);
   const openapiSpec = path.join(config.sbtDataDir, "openapi-spec.json");
   const schemaspyOut = path.join(config.sbtDataDir, "schemaspy-out");
@@ -108,7 +105,6 @@ try {
     case "stop":
       ensureProjectDirs();
       run(`docker compose -f "${COMPOSE_DB}" --env-file "${SBT_ENV_FILE}" down`);
-      try { execSync(`docker compose -f "${COMPOSE_DOCS}" --env-file "${SBT_ENV_FILE}" down`, { stdio: "inherit", cwd: config.toolsDir }); } catch { /* ok */ }
       break;
 
     case "restart":
@@ -128,48 +124,8 @@ try {
       await runSnapshot();
       break;
 
-    case "generate-atlas": {
+    case "generate-atlas":
       await runGenerateData();
-      // Invoke atlas-html plugin if loaded
-      const atlasCmd = pluginCommands.find((pc) => pc.cmd.name === "atlas-html");
-      if (atlasCmd) {
-        const ctx = buildPluginContext(atlasCmd.loaded, loaded);
-        await atlasCmd.cmd.run(args, ctx);
-      }
-      break;
-    }
-
-    case "docs":
-      if (args.includes("stop")) {
-        ensureProjectDirs();
-        run(`docker compose -f "${COMPOSE_DOCS}" --env-file "${SBT_ENV_FILE}" down`);
-      } else {
-        ensureProjectDirs();
-        // Auto-generate snapshot if missing
-        const metaFile = path.join(resolve(config.paths.snapshot), "_meta", "snapshot.json");
-        if (!fs.existsSync(metaFile)) {
-          ui.step("📸 Snapshot not found. Generating DB snapshot first...\n");
-          try { await runSnapshot(); } catch { ui.warn("⚠️  Snapshot generation failed. Continuing...\n"); }
-        }
-        // Generate atlas data + HTML
-        ui.step("📊 Generating atlas visualization...\n");
-        try {
-          await runGenerateData();
-          const atlasCmd = pluginCommands.find((pc) => pc.cmd.name === "atlas-html");
-          if (atlasCmd) await atlasCmd.cmd.run([], buildPluginContext(atlasCmd.loaded, loaded));
-        } catch { ui.warn("⚠️  Atlas generation skipped.\n"); }
-        // Generate ERD
-        const erdCmd = pluginCommands.find((pc) => pc.cmd.name === "generate-erd");
-        if (erdCmd) {
-          ui.step("📐 Generating ERD diagrams...\n");
-          try { await erdCmd.cmd.run([], buildPluginContext(erdCmd.loaded, loaded)); } catch { ui.warn("⚠️  ERD generation skipped.\n"); }
-        }
-        // Start docs server
-        const docsCmd = pluginCommands.find((pc) => pc.cmd.name === "start-docs-server");
-        if (docsCmd) {
-          await docsCmd.cmd.run([], buildPluginContext(docsCmd.loaded, loaded));
-        }
-      }
       break;
 
     case "init":

--- a/packages/core/src/commands/help.ts
+++ b/packages/core/src/commands/help.ts
@@ -15,8 +15,7 @@ const CORE_COMMANDS: CommandMeta[] = [
   { name: "status", description: "Show service URLs, keys, and connection info", category: "Docker" },
   { name: "migrate", description: "Apply SQL migrations to running DB", category: "Database" },
   { name: "snapshot", description: "Export DB objects (functions, views, etc.) to filesystem", category: "Database" },
-  { name: "generate-atlas", description: "Generate the Backend Atlas HTML visualization", category: "Code Generation" },
-  { name: "docs", description: "Generate atlas + start Swagger UI, ReDoc, SchemaSpy", category: "Docs" },
+  { name: "generate-atlas", description: "Generate Backend Atlas data (JSON)", category: "Code Generation" },
   { name: "init", description: "Generate supabase-tools.config.json with defaults", category: "Setup" },
   { name: "help", description: "Show this help", category: "Setup" },
 ];
@@ -31,20 +30,9 @@ function inferCategory(cmdName: string): string {
 }
 
 export function showHelp(pluginCommands: { plugin: string; cmd: SbtPluginCommand }[]): void {
-  const pluginNames = new Set(pluginCommands.map((pc) => pc.cmd.name));
-
-  // Build category -> commands map (avoid duplicating core commands that are also plugin-provided)
   const byCategory = new Map<string, { name: string; description: string; source?: string }[]>();
 
   for (const meta of CORE_COMMANDS) {
-    // Skip core entries for commands that come from plugins (plugin wins for description)
-    if (meta.name === "generate-atlas" && pluginNames.has("atlas-html")) {
-      // generate-atlas is core-orchestrated, always show
-    }
-    if (pluginNames.has(meta.name) && meta.category !== "Docker" && meta.category !== "Database" && meta.category !== "Setup") {
-      // Prefer plugin's description
-      continue;
-    }
     const list = byCategory.get(meta.category) ?? [];
     list.push({ name: meta.name, description: meta.description });
     byCategory.set(meta.category, list);

--- a/packages/core/src/commands/migrate.ts
+++ b/packages/core/src/commands/migrate.ts
@@ -1,14 +1,13 @@
 import fs from "node:fs";
 import path from "node:path";
 import { spawnSync, type SpawnSyncReturns } from "node:child_process";
-import { ui } from "@sbtools/sdk";
+import { ui, sanitizeContainerPrefix } from "@sbtools/sdk";
 import { config, resolve } from "../config.js";
 
 export async function runMigrate(): Promise<void> {
   const MIGRATIONS_DIR = resolve(config.paths.migrations);
 
-  const prefix = config.project.name
-    .replace(/[^a-zA-Z0-9-]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "").toLowerCase() || "sbt";
+  const prefix = sanitizeContainerPrefix(config.project.name);
   const DB_CONTAINER = `${prefix}-supabase-db`;
 
   const sleep = (ms: number): void => {

--- a/packages/core/src/commands/status.ts
+++ b/packages/core/src/commands/status.ts
@@ -1,13 +1,12 @@
 import path from "node:path";
-import { ui, extractComposeKey } from "@sbtools/sdk";
+import { ui, extractComposeKey, extractSupabaseKeys } from "@sbtools/sdk";
 import { config } from "../config.js";
 import { loadPlugins, buildPluginContext } from "../plugin-loader.js";
 
 export async function runStatus(): Promise<void> {
   const composePath = path.join(config.toolsDir, "docker-compose.db.yml");
 
-  const anonKey = extractComposeKey(composePath, [/SUPABASE_ANON_KEY:\s*([^\s]+)/, /ANON_KEY:\s*([^\s]+)/]);
-  const serviceKey = extractComposeKey(composePath, [/SUPABASE_SERVICE_ROLE_KEY:\s*([^\s]+)/, /SUPABASE_SERVICE_KEY:\s*([^\s]+)/, /SERVICE_KEY:\s*([^\s]+)/]);
+  const { anonKey, serviceKey } = extractSupabaseKeys(composePath);
   const jwtSecret = extractComposeKey(composePath, [/JWT_SECRET:\s*([^\s]+)/, /AUTH_JWT_SECRET:\s*([^\s]+)/]);
 
   const api = config.api.url;

--- a/packages/core/src/preflight.ts
+++ b/packages/core/src/preflight.ts
@@ -37,13 +37,6 @@ const composeDb = (): Check => ({
   kind: "file",
 });
 
-const composeDocs = (): Check => ({
-  path: path.join(config.toolsDir, "docker-compose.api-docs.yml"),
-  label: "Docker Compose API-docs config",
-  fix: "This file ships with supabase-tools. Re-clone or restore it.",
-  kind: "file",
-});
-
 const snapshotMeta = (): Check => ({
   path: path.join(resolve(config.paths.snapshot), "_meta", "snapshot.json"),
   label: "DB snapshot metadata",
@@ -82,10 +75,6 @@ function checksForCommand(command: string, args: string[]): Check[] {
 
     case "generate-atlas":
       return [snapshotMeta()];
-
-    case "docs":
-      if (args.includes("stop")) return [];
-      return [composeDb(), composeDocs()];
 
     default:
       return [];

--- a/packages/core/tests/utils.test.ts
+++ b/packages/core/tests/utils.test.ts
@@ -1,37 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { safeName, safeFileName } from "@sbtools/sdk";
 import {
-  sanitizeDbUrl, parseSchemaArgs, getSchemaFilter,
-  normalizeWhitespace, splitArgs,
+  sanitizeDbUrl,
+  parseSchemaArgs,
+  getSchemaFilter,
+  normalizeWhitespace,
+  splitArgs,
 } from "../src/utils/index.js";
-
-describe("safeName", () => {
-  it("passes through simple names", () => {
-    expect(safeName("public")).toBe("public");
-  });
-  it("replaces special characters with underscore", () => {
-    expect(safeName("my schema!@#")).toBe("my_schema___");
-  });
-  it("preserves dots and hyphens", () => {
-    expect(safeName("a.b-c")).toBe("a.b-c");
-  });
-});
-
-describe("safeFileName", () => {
-  it("returns short names as-is", () => {
-    expect(safeFileName("test.sql")).toBe("test.sql");
-  });
-  it("truncates long names and adds hash", () => {
-    const long = "a".repeat(200) + ".sql";
-    const result = safeFileName(long, 180);
-    expect(result.length).toBeLessThanOrEqual(180);
-    expect(result.endsWith(".sql")).toBe(true);
-  });
-  it("produces deterministic output", () => {
-    const name = "x".repeat(200) + ".sql";
-    expect(safeFileName(name)).toBe(safeFileName(name));
-  });
-});
 
 describe("sanitizeDbUrl", () => {
   it("masks password in standard URL", () => {

--- a/packages/plugin-atlas-html/README.md
+++ b/packages/plugin-atlas-html/README.md
@@ -22,6 +22,12 @@ npm run sbt -- atlas-html
 
 Configured via `supabase-tools.config.json` paths. No plugin-specific config required.
 
+## Dependencies
+
+| Type | Requirement |
+|------|-------------|
+| Files | `docs/backend-atlas-data.json` must exist (run `sbt generate-atlas` first) |
+
 ## Project Structure
 
 ```

--- a/packages/plugin-atlas-html/index.ts
+++ b/packages/plugin-atlas-html/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./src/index.js";

--- a/packages/plugin-atlas-html/src/index.ts
+++ b/packages/plugin-atlas-html/src/index.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { ui, ensureDir } from "@sbtools/sdk";
+import { ui, ensureDir, SbtError } from "@sbtools/sdk";
 import type { SbtPlugin, PluginContext, PluginAtlasUI } from "@sbtools/sdk";
 import { atlasStyles } from "./atlas/styles/base.js";
 import { cardStyles } from "./atlas/styles/cards.js";
@@ -20,6 +20,13 @@ const plugin: SbtPlugin = {
       name: "atlas-html",
       description: "Generate the Backend Atlas HTML visualization",
       async run(_args: string[], ctx: PluginContext): Promise<void> {
+        const dataFile = path.join(ctx.paths.docsOutput, "backend-atlas-data.json");
+        if (!fs.existsSync(dataFile)) {
+          throw new SbtError("PREFLIGHT_FAILED", "backend-atlas-data.json not found.", {
+            tips: ["Run `sbt generate-atlas` first to generate the atlas data."],
+          });
+        }
+
         const OUT_DIR = ctx.paths.docsOutput;
         const OUT_FILE = path.join(OUT_DIR, "backend-atlas.html");
         ensureDir(OUT_DIR);

--- a/packages/plugin-db-test/README.md
+++ b/packages/plugin-db-test/README.md
@@ -26,6 +26,15 @@ npm run sbt -- test --mem
 | `testsDir` | `supabase/tests` | Directory containing .sql test files |
 | `migrationsDir` | `supabase/migrations` | Migrations to apply in --mem mode |
 
+## Dependencies
+
+| Type | Requirement |
+|------|-------------|
+| Docker | Must be running for live mode (`sbt test`) |
+| Database | DB must be running and accessible for live mode |
+| Files | `supabase/tests` — test SQL files must exist |
+| Files | Migrations dir must exist for `--mem` mode (no Docker needed) |
+
 ## Project Structure
 
 ```

--- a/packages/plugin-db-test/index.ts
+++ b/packages/plugin-db-test/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./src/index.js";

--- a/packages/plugin-deno-functions/README.md
+++ b/packages/plugin-deno-functions/README.md
@@ -89,6 +89,14 @@ Place a `metadata.json` next to `index.ts` in any function directory to override
 | `baseUrl` | `/functions/v1` | URL prefix for edge function endpoints |
 | `configTomlPath` | `supabase/config.toml` | Path to Supabase config.toml (for `verify_jwt` settings) |
 
+## Dependencies
+
+| Type | Requirement |
+|------|-------------|
+| Files | `supabase/functions` — edge function source directories must exist |
+
+No Docker or database required for listing. OpenAPI generation needs a running API for full spec.
+
 ## Requirements
 
 - Node.js 18+

--- a/packages/plugin-depgraph/README.md
+++ b/packages/plugin-depgraph/README.md
@@ -71,11 +71,17 @@ Add to `supabase-tools.config.json`:
 
 No config fields needed — all paths are derived from the plugin context.
 
+## Dependencies
+
+| Type | Requirement |
+|------|-------------|
+| Files | `docs/backend-atlas-data.json` must exist (run `sbt generate-atlas` first) |
+| Files | Snapshot dir (types, functions, etc.) for FK/enum detection — optional; works with atlas data only |
+
 ## Requirements
 
 - Node.js 18+
 - `tsx` (installed as devDependency in the parent project)
-- `docs/backend-atlas-data.json` must exist (run `sbt generate-atlas` first)
 - No additional npm dependencies
 
 ## Project Structure

--- a/packages/plugin-depgraph/src/graph-builder.ts
+++ b/packages/plugin-depgraph/src/graph-builder.ts
@@ -7,6 +7,7 @@
  */
 import fs from "node:fs";
 import path from "node:path";
+import { SbtError } from "@sbtools/sdk";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -284,10 +285,9 @@ export function buildGraph(
 
   // Load atlas data
   if (!fs.existsSync(atlasDataPath)) {
-    console.error(
-      `Atlas data not found at ${atlasDataPath}. Run 'sbt generate-atlas' first.`,
-    );
-    return { nodes: [], edges: [] };
+    throw new SbtError("PREFLIGHT_FAILED", `Atlas data not found at ${atlasDataPath}.`, {
+      tips: ["Run `sbt generate-atlas` first to generate the atlas data."],
+    });
   }
 
   const atlas: AtlasData = JSON.parse(

--- a/packages/plugin-depgraph/src/index.ts
+++ b/packages/plugin-depgraph/src/index.ts
@@ -13,9 +13,10 @@
  *     "config": {}
  *   }]
  */
+import fs from "node:fs";
 import path from "node:path";
 import type { SbtPlugin, PluginContext } from "@sbtools/sdk";
-import { hasFlag, openFile } from "@sbtools/sdk";
+import { hasFlag, openFile, SbtError } from "@sbtools/sdk";
 import { buildGraph } from "./graph-builder.js";
 import { generateMermaid, writeMermaid } from "./mermaid-generator.js";
 import { generateHtml, writeHtml } from "./html-generator.js";
@@ -69,6 +70,13 @@ and supabase/current/ snapshot files. No running database is required.
   }
 
   const paths = resolvePaths(ctx);
+
+  if (!fs.existsSync(paths.atlasDataPath)) {
+    throw new SbtError("PREFLIGHT_FAILED", `Atlas data not found at ${paths.atlasDataPath}.`, {
+      tips: ["Run `sbt generate-atlas` first to generate the atlas data."],
+    });
+  }
+
   const graph = buildGraph(paths.atlasDataPath, paths.snapshotDir, paths.typesFilePath);
 
   if (graph.nodes.length === 0) {

--- a/packages/plugin-depgraph/src/mermaid-generator.ts
+++ b/packages/plugin-depgraph/src/mermaid-generator.ts
@@ -6,6 +6,7 @@
  */
 import fs from "node:fs";
 import path from "node:path";
+import { sanitizeIdentifier } from "@sbtools/sdk";
 import type { DependencyGraph, GraphNode } from "./graph-builder.js";
 
 // ---------------------------------------------------------------------------
@@ -14,7 +15,7 @@ import type { DependencyGraph, GraphNode } from "./graph-builder.js";
 
 /** Sanitize a node id into a valid Mermaid identifier. */
 function mermaidId(id: string): string {
-  return id.replace(/[^a-zA-Z0-9_]/g, "_");
+  return sanitizeIdentifier(id);
 }
 
 /** Escape label text for Mermaid. */

--- a/packages/plugin-docs-server/README.md
+++ b/packages/plugin-docs-server/README.md
@@ -1,23 +1,42 @@
 # @sbtools/plugin-docs-server
 
-Plugin for [supabase-tools](https://github.com/supabase/supabase) that starts API documentation services: Swagger UI, ReDoc, and Backend Atlas via Docker Compose.
+Plugin for [supabase-tools](https://github.com/supabase/supabase) that starts API documentation services: Swagger UI, ReDoc, Backend Atlas, and SchemaSpy via Docker Compose. Supports granular subcommands so you can start only the services you need.
 
 ## Quick Start
 
 ```bash
-# Start documentation services
-npm run sbt -- start-docs-server
+# Start all documentation services
+npm run sbt -- docs
 
-# Stop
-npm run sbt -- start-docs-server stop
+# Start only Swagger UI
+npm run sbt -- docs swagger
+
+# Stop all docs containers
+npm run sbt -- docs stop
 ```
 
 ## Commands
 
 | Command | Description |
 |---------|-------------|
-| `start-docs-server` | Start Swagger UI, ReDoc, and Atlas on configured ports |
-| `start-docs-server stop` | Stop all documentation containers |
+| `docs` or `docs all` | Start all documentation services |
+| `docs swagger` | Swagger UI only (port 8081) |
+| `docs redoc` | ReDoc only (port 8082) |
+| `docs atlas` | Backend Atlas only (port 8083/atlas/) |
+| `docs schemaspy` | SchemaSpy only (port 8083/schemaspy/) |
+| `docs stop` | Stop all documentation containers |
+
+## Dependencies
+
+Per-subcommand (only what you run):
+
+| Subcommand | Type | Requirement |
+|------------|------|-------------|
+| `docs swagger` / `docs redoc` | Docker | Must be running |
+| `docs swagger` / `docs redoc` | Files | `docker-compose.api-docs.yml`, `.env` in sbtDataDir |
+| `docs atlas` | Files | `backend-atlas-data.json` AND `backend-atlas.html` must exist (run `sbt generate-atlas` + `sbt atlas-html` first) |
+| `docs schemaspy` | Docker | Must be running; DB container must be accessible |
+| `docs all` | All | All of the above |
 
 ## Configuration
 
@@ -28,7 +47,7 @@ Uses `api.url` and Docker compose files from supabase-tools. Fetches OpenAPI spe
 ```
 packages/plugin-docs-server/
 ├── src/
-│   └── index.ts   # Plugin entry, start-docs-server command
+│   └── index.ts   # Plugin entry, docs command with subcommands
 ├── package.json
 ├── tsconfig.json
 └── README.md

--- a/packages/plugin-docs-server/index.ts
+++ b/packages/plugin-docs-server/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./src/index.js";

--- a/packages/plugin-docs-server/src/index.ts
+++ b/packages/plugin-docs-server/src/index.ts
@@ -1,8 +1,291 @@
 import { execSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { ui, SbtError, extractComposeKey } from "@sbtools/sdk";
+import { ui, SbtError, extractSupabaseKeys } from "@sbtools/sdk";
 import type { SbtPlugin, PluginContext } from "@sbtools/sdk";
+
+// ---------------------------------------------------------------------------
+// Subcommand types
+// ---------------------------------------------------------------------------
+
+type DocsSubcommand = "swagger" | "redoc" | "atlas" | "schemaspy" | "all" | "stop";
+
+const VALID_SUBCOMMANDS = new Set<string>(["swagger", "redoc", "atlas", "schemaspy", "all", "stop"]);
+
+const SERVICE_MAP: Record<string, string[]> = {
+  swagger:  ["swagger-ui"],
+  redoc:    ["redoc"],
+  atlas:    ["docs-server"],
+  schemaspy: ["schemaspy", "docs-server"],
+  all:      [],  // empty = start all services
+};
+
+const SERVICE_URLS: Record<string, [string, string]> = {
+  swagger:  ["Swagger UI",    "http://localhost:8081"],
+  redoc:    ["ReDoc",         "http://localhost:8082"],
+  atlas:    ["Backend Atlas", "http://localhost:8083/atlas/"],
+  schemaspy: ["SchemaSpy",     "http://localhost:8083/schemaspy/"],
+};
+
+// ---------------------------------------------------------------------------
+// Preflight helpers
+// ---------------------------------------------------------------------------
+
+function preflightOpenApi(
+  ctx: PluginContext,
+  specPath: string,
+  dbComposePath: string,
+): void {
+  // Ensure compose files exist
+  const composePath = path.join(ctx.toolsDir, "docker-compose.api-docs.yml");
+  if (!existsSync(composePath)) {
+    throw new SbtError("PREFLIGHT_FAILED", "docker-compose.api-docs.yml not found.", {
+      tips: ["This file ships with supabase-tools. Re-clone or restore it."],
+    });
+  }
+  if (!existsSync(path.join(ctx.sbtDataDir, ".env"))) {
+    throw new SbtError("PREFLIGHT_FAILED", ".env file not found in .sbt/.", {
+      tips: ["Run `sbt init` to create project directories and env file."],
+    });
+  }
+  // OpenAPI spec will be fetched or a placeholder created -- no hard fail needed
+}
+
+function preflightAtlas(ctx: PluginContext): void {
+  const dataFile = path.join(ctx.paths.docsOutput, "backend-atlas-data.json");
+  const htmlFile = path.join(ctx.paths.docsOutput, "backend-atlas.html");
+  const missing: string[] = [];
+  if (!existsSync(dataFile)) missing.push("backend-atlas-data.json");
+  if (!existsSync(htmlFile)) missing.push("backend-atlas.html");
+  if (missing.length > 0) {
+    throw new SbtError("PREFLIGHT_FAILED", `Atlas files missing: ${missing.join(", ")}`, {
+      tips: [
+        "Run `sbt generate-atlas` to generate the data file.",
+        "Run `sbt atlas-html` to generate the HTML page.",
+      ],
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// OpenAPI spec preparation (fetch + merge)
+// ---------------------------------------------------------------------------
+
+async function ensureOpenApiSpec(
+  ctx: PluginContext,
+  specPath: string,
+  dbComposePath: string,
+): Promise<void> {
+  ui.step("Preparing OpenAPI spec...\n");
+
+  const { anonKey, serviceKey } = extractSupabaseKeys(dbComposePath);
+  const key = serviceKey || anonKey;
+
+  let fetched = false;
+  if (key) {
+    try {
+      const res = await fetch(`${ctx.apiUrl}/rest/v1/`, {
+        headers: { apikey: key, Authorization: `Bearer ${key}` },
+      });
+      if (res.ok) {
+        const spec = await res.json();
+        const pathCount = Object.keys(spec.paths || {}).length;
+        writeFileSync(specPath, JSON.stringify(spec, null, 2), "utf8");
+        ui.success(`OpenAPI spec fetched (${pathCount} endpoints).\n`);
+        fetched = true;
+      } else {
+        ui.warn(`Failed to fetch OpenAPI spec: ${res.status} ${res.statusText}`);
+      }
+    } catch {
+      ui.warn("Could not reach REST API to fetch OpenAPI spec (is the DB running?)");
+    }
+  } else {
+    ui.warn("Could not find API key in docker-compose.db.yml");
+  }
+
+  if (!fetched) {
+    if (!existsSync(specPath)) {
+      const placeholder = {
+        openapi: "3.0.0",
+        info: { title: "Supabase REST API", description: "Run 'sbt start' then 'sbt docs swagger' to generate the full spec.", version: "0.0.0" },
+        paths: {},
+      };
+      writeFileSync(specPath, JSON.stringify(placeholder, null, 2), "utf8");
+    }
+    ui.detail("   Using existing/placeholder spec. Re-run with DB running for full spec.\n");
+  }
+
+  // Merge plugin OpenAPI specs from siblings
+  const siblingPlugins = ctx.siblingPlugins ?? [];
+  const pluginsWithSpec = siblingPlugins.filter((p) => p.getOpenApiSpec);
+
+  if (pluginsWithSpec.length > 0) {
+    ui.step("Merging plugin OpenAPI specs...\n");
+
+    const spec = JSON.parse(readFileSync(specPath, "utf8")) as Record<string, unknown>;
+    const specPaths = (spec.paths ?? {}) as Record<string, unknown>;
+    const specComponents = (spec.components ?? {}) as Record<string, Record<string, unknown>>;
+    const specTags = (spec.tags ?? []) as { name: string; description?: string }[];
+
+    for (const sibling of pluginsWithSpec) {
+      try {
+        const pluginSpec = await sibling.getOpenApiSpec!(ctx);
+        const pPaths = (pluginSpec.paths ?? {}) as Record<string, unknown>;
+        Object.assign(specPaths, pPaths);
+
+        const pComponents = (pluginSpec.components ?? {}) as Record<string, Record<string, unknown>>;
+        for (const [section, entries] of Object.entries(pComponents)) {
+          if (!specComponents[section]) specComponents[section] = {};
+          Object.assign(specComponents[section], entries);
+        }
+
+        const pTags = (pluginSpec.tags ?? []) as { name: string; description?: string }[];
+        for (const tag of pTags) {
+          if (!specTags.some((t) => t.name === tag.name)) specTags.push(tag);
+        }
+
+        ui.detail(`   ${sibling.name}: ${Object.keys(pPaths).length} path(s) merged.`);
+      } catch (err) {
+        ui.warn(`   ${sibling.name} getOpenApiSpec failed: ${(err as Error).message}`);
+      }
+    }
+
+    spec.paths = specPaths;
+    spec.components = specComponents;
+    if (specTags.length > 0) spec.tags = specTags;
+
+    writeFileSync(specPath, JSON.stringify(spec, null, 2), "utf8");
+    ui.info(`\n   Combined spec: ${Object.keys(specPaths).length} total paths.\n`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Docker helpers
+// ---------------------------------------------------------------------------
+
+function composeUp(
+  composePath: string,
+  envFile: string,
+  toolsDir: string,
+  services: string[],
+): void {
+  const serviceArgs = services.length > 0 ? ` ${services.join(" ")}` : "";
+  execSync(
+    `docker compose -f "${composePath}" --env-file "${envFile}" up -d --force-recreate${serviceArgs}`,
+    { stdio: "inherit", cwd: toolsDir },
+  );
+}
+
+function composeDown(composePath: string, envFile: string, toolsDir: string): void {
+  execSync(
+    `docker compose -f "${composePath}" --env-file "${envFile}" down`,
+    { stdio: "inherit", cwd: toolsDir },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Help
+// ---------------------------------------------------------------------------
+
+function showDocsHelp(): void {
+  console.log(`
+docs — Start API documentation services
+
+Usage:
+  sbt docs [subcommand] [stop]
+
+Subcommands:
+  swagger    Swagger UI only (port 8081). Needs openapi-spec.
+  redoc      ReDoc only (port 8082). Needs openapi-spec.
+  atlas      Backend Atlas only (port 8083/atlas/). Needs sbt generate-atlas + sbt atlas-html.
+  schemaspy  SchemaSpy only (port 8083/schemaspy/). Needs DB running.
+  all        All services (default if no subcommand).
+  stop       Stop all docs containers.
+
+Options:
+  -h, --help  Show this help
+`);
+}
+
+// ---------------------------------------------------------------------------
+// Main command handler
+// ---------------------------------------------------------------------------
+
+async function docsCommand(args: string[], ctx: PluginContext): Promise<void> {
+  if (args.includes("--help") || args.includes("-h")) {
+    showDocsHelp();
+    return;
+  }
+
+  const composePath = path.join(ctx.toolsDir, "docker-compose.api-docs.yml");
+  const dbComposePath = path.join(ctx.toolsDir, "docker-compose.db.yml");
+  const specPath = path.join(ctx.sbtDataDir, "openapi-spec.json");
+  const envFile = path.join(ctx.sbtDataDir, ".env");
+
+  // Parse subcommand
+  const sub = args.find((a) => !a.startsWith("-")) as DocsSubcommand | undefined;
+  const subcommand: DocsSubcommand = sub && VALID_SUBCOMMANDS.has(sub) ? sub as DocsSubcommand : "all";
+
+  // Handle stop
+  if (subcommand === "stop" || args.includes("stop")) {
+    ui.step("Stopping documentation services...");
+    try {
+      composeDown(composePath, envFile, ctx.toolsDir);
+    } catch {
+      // Containers may not be running
+    }
+    ui.success("Documentation services stopped.");
+    return;
+  }
+
+  // Run preflight for the requested subcommand(s)
+  const needsOpenApi = subcommand === "swagger" || subcommand === "redoc" || subcommand === "all";
+  const needsAtlas = subcommand === "atlas" || subcommand === "all";
+
+  preflightOpenApi(ctx, specPath, dbComposePath);
+  if (needsAtlas) preflightAtlas(ctx);
+
+  // Prepare OpenAPI spec if needed
+  if (needsOpenApi) {
+    await ensureOpenApiSpec(ctx, specPath, dbComposePath);
+  }
+
+  // Start the requested services
+  const services = SERVICE_MAP[subcommand] ?? [];
+  ui.heading(`\nStarting docs services (${subcommand})...\n`);
+
+  try {
+    composeUp(composePath, envFile, ctx.toolsDir, services);
+
+    ui.info("\nWaiting for services to start...\n");
+    await new Promise((r) => setTimeout(r, 2000));
+
+    ui.success("\nDocumentation Services Started!\n");
+    ui.separator();
+    ui.heading("\nAvailable:\n");
+
+    const urlsToShow = subcommand === "all"
+      ? Object.values(SERVICE_URLS)
+      : subcommand === "schemaspy"
+        ? [SERVICE_URLS.schemaspy]
+        : [SERVICE_URLS[subcommand]];
+
+    ui.table(urlsToShow, 2);
+    ui.blank();
+    ui.separator();
+    ui.info(`\nTo stop: sbt docs stop\n`);
+  } catch (error) {
+    throw new SbtError(
+      "COMMAND_FAILED",
+      `Error starting documentation services: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error, tips: ["Ensure Docker is running: start Docker Desktop"] },
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Plugin export
+// ---------------------------------------------------------------------------
 
 const plugin: SbtPlugin = {
   name: "@sbtools/plugin-docs-server",
@@ -10,148 +293,9 @@ const plugin: SbtPlugin = {
 
   commands: [
     {
-      name: "start-docs-server",
-      description: "Start API documentation services (Swagger UI, ReDoc, Backend Atlas)",
-      async run(args: string[], ctx: PluginContext): Promise<void> {
-        const composePath = path.join(ctx.toolsDir, "docker-compose.api-docs.yml");
-        const dbComposePath = path.join(ctx.toolsDir, "docker-compose.db.yml");
-        const specPath = path.join(ctx.sbtDataDir, "openapi-spec.json");
-        const envFile = path.join(ctx.sbtDataDir, ".env");
-
-        // Handle stop command
-        if (args.includes("stop")) {
-          ui.step("Stopping documentation services...");
-          execSync(`docker compose -f "${composePath}" --env-file "${envFile}" down`, {
-            stdio: "inherit",
-            cwd: ctx.toolsDir,
-          });
-          ui.success("Documentation services stopped.");
-          return;
-        }
-
-        ui.heading("\nStarting API documentation services...\n");
-
-        // Fetch OpenAPI spec
-        ui.step("Fetching OpenAPI spec from REST API...\n");
-
-        const serviceKey = extractComposeKey(dbComposePath, [
-          /SUPABASE_SERVICE_ROLE_KEY:\s*([^\s]+)/,
-          /SUPABASE_SERVICE_KEY:\s*([^\s]+)/,
-          /SERVICE_KEY:\s*([^\s]+)/,
-        ]);
-        const anonKey = extractComposeKey(dbComposePath, [
-          /SUPABASE_ANON_KEY:\s*([^\s]+)/,
-          /ANON_KEY:\s*([^\s]+)/,
-        ]);
-        const key = serviceKey || anonKey;
-
-        let fetched = false;
-        if (key) {
-          try {
-            const res = await fetch(`${ctx.apiUrl}/rest/v1/`, {
-              headers: { apikey: key, Authorization: `Bearer ${key}` },
-            });
-            if (res.ok) {
-              const spec = await res.json();
-              const pathCount = Object.keys(spec.paths || {}).length;
-              writeFileSync(specPath, JSON.stringify(spec, null, 2), "utf8");
-              ui.success(`OpenAPI spec fetched (${pathCount} endpoints).\n`);
-              fetched = true;
-            } else {
-              ui.warn(`Failed to fetch OpenAPI spec: ${res.status} ${res.statusText}`);
-            }
-          } catch {
-            ui.warn("Could not reach REST API to fetch OpenAPI spec (is the DB running?)");
-          }
-        } else {
-          ui.warn("Could not find API key in docker-compose.db.yml");
-        }
-
-        if (!fetched) {
-          if (!existsSync(specPath)) {
-            const placeholder = {
-              openapi: "3.0.0",
-              info: { title: "Supabase REST API", description: "Run 'sbt start' then 'sbt docs' to generate the full spec.", version: "0.0.0" },
-              paths: {},
-            };
-            writeFileSync(specPath, JSON.stringify(placeholder, null, 2), "utf8");
-          }
-          ui.detail("   Using placeholder spec. Re-run 'docs' with DB running for full spec.\n");
-        }
-
-        // Merge plugin OpenAPI specs from siblings
-        const siblingPlugins = ctx.siblingPlugins ?? [];
-        const pluginsWithSpec = siblingPlugins.filter((p) => p.getOpenApiSpec);
-
-        if (pluginsWithSpec.length > 0) {
-          ui.step("Merging plugin OpenAPI specs...\n");
-
-          const spec = JSON.parse(readFileSync(specPath, "utf8")) as Record<string, unknown>;
-          const specPaths = (spec.paths ?? {}) as Record<string, unknown>;
-          const specComponents = (spec.components ?? {}) as Record<string, Record<string, unknown>>;
-          const specTags = (spec.tags ?? []) as { name: string; description?: string }[];
-
-          for (const sibling of pluginsWithSpec) {
-            try {
-              const pluginSpec = await sibling.getOpenApiSpec!(ctx);
-              const pPaths = (pluginSpec.paths ?? {}) as Record<string, unknown>;
-              Object.assign(specPaths, pPaths);
-
-              const pComponents = (pluginSpec.components ?? {}) as Record<string, Record<string, unknown>>;
-              for (const [section, entries] of Object.entries(pComponents)) {
-                if (!specComponents[section]) specComponents[section] = {};
-                Object.assign(specComponents[section], entries);
-              }
-
-              const pTags = (pluginSpec.tags ?? []) as { name: string; description?: string }[];
-              for (const tag of pTags) {
-                if (!specTags.some((t) => t.name === tag.name)) specTags.push(tag);
-              }
-
-              ui.detail(`   ${sibling.name}: ${Object.keys(pPaths).length} path(s) merged.`);
-            } catch (err) {
-              ui.warn(`   ${sibling.name} getOpenApiSpec failed: ${(err as Error).message}`);
-            }
-          }
-
-          spec.paths = specPaths;
-          spec.components = specComponents;
-          if (specTags.length > 0) spec.tags = specTags;
-
-          writeFileSync(specPath, JSON.stringify(spec, null, 2), "utf8");
-          ui.info(`\n   Combined spec: ${Object.keys(specPaths).length} total paths.\n`);
-        }
-
-        try {
-          ui.step("Starting Docker containers...\n");
-          execSync(`docker compose -f "${composePath}" --env-file "${envFile}" up -d --force-recreate`, {
-            stdio: "inherit",
-            cwd: ctx.toolsDir,
-          });
-
-          ui.info("\nWaiting for services to start...\n");
-          await new Promise((r) => setTimeout(r, 2000));
-
-          ui.success("\nAPI Documentation Services Started!\n");
-          ui.separator();
-          ui.heading("\nAvailable Documentation:\n");
-          ui.table([
-            ["Swagger UI",    "http://localhost:8081"],
-            ["ReDoc",         "http://localhost:8082"],
-            ["Backend Atlas", "http://localhost:8083/atlas/"],
-            ["SchemaSpy",     "http://localhost:8083/schemaspy/"],
-          ], 2);
-          ui.blank();
-          ui.separator();
-          ui.info(`\nTo stop: sbt docs stop\n`);
-        } catch (error) {
-          throw new SbtError(
-            "COMMAND_FAILED",
-            `Error starting API documentation services: ${error instanceof Error ? error.message : String(error)}`,
-            { cause: error, tips: ["Ensure Docker is running: start Docker Desktop"] },
-          );
-        }
-      },
+      name: "docs",
+      description: "Start documentation services (swagger, redoc, atlas, schemaspy)",
+      run: docsCommand,
     },
   ],
 };

--- a/packages/plugin-erd/README.md
+++ b/packages/plugin-erd/README.md
@@ -37,6 +37,12 @@ Plugin config goes in `plugins[].config`:
 | `erdOutput` | `<docsOutput>/entity-relations` | Output directory for .md files |
 | `displayColumns` | `["name", "email", "full_name", "slug", "title"]` | Column names to display on referenced entities |
 
+## Dependencies
+
+| Type | Requirement |
+|------|-------------|
+| Database | `DATABASE_URL` or `config.db.url`; DB must be running and accessible |
+
 ## Project Structure
 
 ```

--- a/packages/plugin-erd/index.ts
+++ b/packages/plugin-erd/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./src/index.js";

--- a/packages/plugin-erd/src/index.ts
+++ b/packages/plugin-erd/src/index.ts
@@ -1,9 +1,8 @@
-import fs from "node:fs";
 import path from "node:path";
 import { Client } from "pg";
 import { ui, ensureDir } from "@sbtools/sdk";
 import type { SbtPlugin, PluginContext } from "@sbtools/sdk";
-import { buildMermaid, updateMarkdown, mapType } from "./builder.js";
+import { buildMermaid, updateMarkdown } from "./builder.js";
 import type { ColumnInfo, ForeignKeyInfo, ReferencedColumn } from "./builder.js";
 
 /** Resolve the ERD output directory from plugin context. */

--- a/packages/plugin-frontend-usage/README.md
+++ b/packages/plugin-frontend-usage/README.md
@@ -51,6 +51,14 @@ npx tsx supabase-tools/cli.ts frontend-usage
 |-----|---------|-------------|
 | `scanPaths` | `["src/"]` | Directories to scan for frontend files |
 
+## Dependencies
+
+| Type | Requirement |
+|------|-------------|
+| Files | Scan paths (default `src/`) must exist |
+
+No Docker or database required.
+
 ## Atlas Integration
 
 - **getAtlasData()**: Component → resource mapping as `frontend_usage` category

--- a/packages/plugin-logs/README.md
+++ b/packages/plugin-logs/README.md
@@ -69,6 +69,13 @@ Add to `supabase-tools.config.json`:
 
 All config fields are optional and have sensible defaults.
 
+## Dependencies
+
+| Type | Requirement |
+|------|-------------|
+| Docker | Must be running; containers discovered via `deriveContainerPrefix` |
+| Config | `project.name` in `supabase-tools.config.json` (or basename fallback) |
+
 ## Requirements
 
 - Docker (services must be running for log tailing)

--- a/packages/plugin-logs/SKILL.md
+++ b/packages/plugin-logs/SKILL.md
@@ -79,7 +79,7 @@ If you see errors about the extension not being available, ensure:
 
 ### Docker
 
-All log tailing and container discovery requires Docker to be running. The plugin discovers containers by deriving the Docker Compose project prefix from `project.name` in `supabase-tools.config.json` (same logic as the main `cli.ts`).
+All log tailing and container discovery requires Docker to be running. The plugin discovers containers by deriving the Docker Compose project prefix from `project.name` in `supabase-tools.config.json` via `@sbtools/sdk`'s `deriveContainerPrefix`.
 
 Container name pattern: `{prefix}-supabase-{service}`
 
@@ -114,11 +114,7 @@ Queries the database via `docker exec <db-container> psql -U postgres -d postgre
 A Node.js HTTP server using only the built-in `http` module. The SSE endpoint spawns `docker logs -f` for each requested service and pipes parsed log lines as JSON events. The HTML page is a self-contained single-page app with inline CSS and JS.
 
 ### Container Discovery
-Reads `supabase-tools.config.json` to get `project.name`, then derives the Docker container prefix using the same sanitisation as `cli.ts`:
-
-```
-prefix = projectName.replace(/[^a-zA-Z0-9-]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "").toLowerCase()
-```
+Reads `supabase-tools.config.json` to get `project.name`, then derives the Docker container prefix via `@sbtools/sdk` (`deriveContainerPrefix` or `sanitizeContainerPrefix`). Same logic used by core `cli.ts` and migrate.
 
 ## File Layout
 

--- a/packages/plugin-logs/src/docker-logs.ts
+++ b/packages/plugin-logs/src/docker-logs.ts
@@ -1,13 +1,14 @@
 /**
  * Docker container discovery and log tailing.
  *
- * Resolves container names from the project config (same prefix derivation
- * as cli.ts), checks running status via `docker inspect`, and spawns
- * `docker logs -f` child processes with proper lifecycle management.
+ * Resolves container names from the project config (prefix from @sbtools/sdk),
+ * checks running status via `docker inspect`, and spawns `docker logs -f`
+ * child processes with proper lifecycle management.
  */
 import { spawn, execSync, type ChildProcess } from "node:child_process";
-import fs from "node:fs";
-import path from "node:path";
+import { deriveContainerPrefix } from "@sbtools/sdk";
+
+export { deriveContainerPrefix };
 
 // ---------------------------------------------------------------------------
 // Service map
@@ -27,30 +28,6 @@ export const SERVICE_MAP: Record<string, string> = {
 };
 
 export const SERVICE_NAMES = Object.keys(SERVICE_MAP);
-
-// ---------------------------------------------------------------------------
-// Container prefix derivation (mirrors cli.ts logic)
-// ---------------------------------------------------------------------------
-
-export function deriveContainerPrefix(projectRoot: string): string {
-  let projectName = path.basename(projectRoot);
-  const configPath = path.join(projectRoot, "supabase-tools.config.json");
-  if (fs.existsSync(configPath)) {
-    try {
-      const cfg = JSON.parse(fs.readFileSync(configPath, "utf8"));
-      if (cfg?.project?.name) projectName = cfg.project.name;
-    } catch {
-      /* use fallback */
-    }
-  }
-  return (
-    projectName
-      .replace(/[^a-zA-Z0-9-]/g, "-")
-      .replace(/-+/g, "-")
-      .replace(/^-|-$/g, "")
-      .toLowerCase() || "sbt"
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Container helpers

--- a/packages/plugin-logs/src/index.ts
+++ b/packages/plugin-logs/src/index.ts
@@ -27,7 +27,6 @@ import {
   registerChild,
   killAllChildren,
   SERVICE_NAMES,
-  SERVICE_MAP,
 } from "./docker-logs.js";
 import { formatLogLine } from "./formatter.js";
 import {
@@ -111,9 +110,9 @@ Plugin config (in supabase-tools.config.json → plugins[].config):
     console.log("\nSupabase Service Status\n");
     console.log(
       "  " +
-        "Service".padEnd(14) +
-        "Container".padEnd(40) +
-        "Status",
+      "Service".padEnd(14) +
+      "Container".padEnd(40) +
+      "Status",
     );
     console.log("  " + "-".repeat(70));
     for (const s of statuses) {
@@ -155,7 +154,7 @@ Plugin config (in supabase-tools.config.json → plugins[].config):
   if (running.length === 0) {
     console.error(
       "No running containers found for the requested services.\n" +
-        "Run `sbt start` first, or use `sbt logs --list` to check status.",
+      "Run `sbt start` first, or use `sbt logs --list` to check status.",
     );
     process.exit(1);
   }

--- a/packages/plugin-scaffold/README.md
+++ b/packages/plugin-scaffold/README.md
@@ -27,6 +27,10 @@ npm run sbt -- scaffold-plugin dashboard --hooks
 
 No config required.
 
+## Dependencies
+
+None — only requires config (`projectRoot`, `toolsDir` from context).
+
 ## Project Structure
 
 ```

--- a/packages/plugin-scaffold/index.ts
+++ b/packages/plugin-scaffold/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./src/index.js";

--- a/packages/plugin-scaffold/src/index.ts
+++ b/packages/plugin-scaffold/src/index.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { SbtPlugin, PluginContext } from "@sbtools/sdk";
-import { ui, hasFlag } from "@sbtools/sdk";
+import { ui, hasFlag, sanitizeSlug } from "@sbtools/sdk";
 import { generatePackageJson } from "./templates/package-json.js";
 import { generateTsconfigJson } from "./templates/tsconfig-json.js";
 import { generateIndexTs } from "./templates/index-ts.js";
@@ -39,7 +39,7 @@ Examples:
     process.exit(1);
   }
 
-  const slug = name.replace(/[^a-z0-9-]/gi, "-").replace(/-+/g, "-").replace(/^-|-$/g, "");
+  const slug = sanitizeSlug(name);
   if (!slug) {
     ui.error("Invalid plugin name. Use alphanumeric and hyphens only.\n");
     process.exit(1);

--- a/packages/plugin-typegen/README.md
+++ b/packages/plugin-typegen/README.md
@@ -35,6 +35,13 @@ Plugin config goes in `plugins[].config`:
 
 Environment: `SUPABASE_TYPES_SCHEMAS` to limit schemas (comma-separated).
 
+## Dependencies
+
+| Type | Requirement |
+|------|-------------|
+| Docker | DB container must be running (PostgREST types endpoint) |
+| Files | `docker-compose.db.yml` in toolsDir (for key extraction) |
+
 ## Project Structure
 
 ```

--- a/packages/plugin-typegen/index.ts
+++ b/packages/plugin-typegen/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./src/index.js";

--- a/packages/plugin-typegen/src/index.ts
+++ b/packages/plugin-typegen/src/index.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { ui, SbtError, extractComposeKey } from "@sbtools/sdk";
+import { ui, SbtError, extractSupabaseKeys } from "@sbtools/sdk";
 import type { SbtPlugin, PluginContext } from "@sbtools/sdk";
 
 /** Resolve the types output file path from plugin context. */
@@ -31,11 +31,7 @@ const plugin: SbtPlugin = {
           });
         }
 
-        const serviceKey = extractComposeKey(composePath, [
-          /SUPABASE_SERVICE_ROLE_KEY:\s*([^\s]+)/,
-          /SUPABASE_SERVICE_KEY:\s*([^\s]+)/,
-          /SERVICE_KEY:\s*([^\s]+)/,
-        ]);
+        const { serviceKey } = extractSupabaseKeys(composePath);
 
         if (!serviceKey) {
           throw new SbtError("COMMAND_FAILED", "Service role key not found in docker-compose.db.yml.", {

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -21,6 +21,13 @@ import type { SbtPlugin, PluginContext } from "@sbtools/sdk";
 - **PluginContext** — Runtime context (`projectRoot`, `toolsDir`, `pluginConfig`, etc.)
 - **ui** — CLI output helpers (`info`, `success`, `warn`, `step`, `table`, etc.)
 - **Error classes** — `ConfigError`, `DatabaseError`, `SnapshotError`, `PluginError`, `SbtError`
-- **Helpers** — `ensureDir`, `readText`, `writeFileInDir`, `safeName`, `safeFileName`, `hasFlag`, `getArg`, `extractComposeKey`
+- **Filesystem** — `ensureDir`, `readText`, `writeFileInDir`, `safeName`, `safeFileName`, `sanitizeSlug`, `sanitizeIdentifier`
+- **Container** — `sanitizeContainerPrefix`, `deriveContainerPrefix` — Docker project prefix from config
+- **Compose** — `extractComposeKey`, `extractSupabaseKeys` — Extract keys from docker-compose files
+- **CLI** — `hasFlag`, `getArg`, `openFile`
+
+## Dependencies
+
+None — pure utilities, no runtime dependencies.
 
 See [SDK docs](https://bazokhan.github.io/supabase-tools/sdk/) for full reference.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -11,31 +11,25 @@
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/bazokhan/supabase-tools.git",
     "directory": "packages/sdk"
   },
-  "engines": {
-    "node": ">=18"
-  },
-  "keywords": [
-    "supabase",
-    "tools"
-  ],
-  "publishConfig": {
-    "access": "public"
-  },
+  "engines": {"node": ">=18"},
+  "keywords": ["supabase", "tools"],
+  "publishConfig": {"access": "public"},
   "scripts": {
     "build": "tsc --project tsconfig.json",
-    "clean": "rimraf dist"
+    "clean": "rimraf dist",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {},
   "devDependencies": {
-    "typescript": "^5.6.0"
+    "typescript": "^5.6.0",
+    "vitest": "^4.0.18"
   }
 }

--- a/packages/sdk/src/compose-utils.ts
+++ b/packages/sdk/src/compose-utils.ts
@@ -3,6 +3,26 @@
  */
 import fs from "node:fs";
 
+/** Regex patterns for Supabase keys in docker-compose. */
+const ANON_KEY_PATTERNS = [
+  /SUPABASE_ANON_KEY:\s*([^\s]+)/,
+  /ANON_KEY:\s*([^\s]+)/,
+];
+
+const SERVICE_KEY_PATTERNS = [
+  /SUPABASE_SERVICE_ROLE_KEY:\s*([^\s]+)/,
+  /SUPABASE_SERVICE_KEY:\s*([^\s]+)/,
+  /SERVICE_KEY:\s*([^\s]+)/,
+];
+
+function extractFirst(content: string, patterns: RegExp[]): string {
+  for (const re of patterns) {
+    const m = content.match(re);
+    if (m?.[1]) return m[1].trim();
+  }
+  return "";
+}
+
 /**
  * Extracts the first matching value from a compose YAML file using regex patterns.
  * Each pattern should have a capturing group for the value (e.g. /KEY:\s*([^\s]+)/).
@@ -18,9 +38,30 @@ export function extractComposeKey(composePath: string, patterns: RegExp[]): stri
   } catch {
     return "";
   }
-  for (const re of patterns) {
-    const m = content.match(re);
-    if (m?.[1]) return m[1].trim();
+  return extractFirst(content, patterns);
+}
+
+export interface SupabaseKeys {
+  anonKey: string;
+  serviceKey: string;
+}
+
+/**
+ * Extracts anon and service_role keys from a Supabase docker-compose file.
+ * Reads the file once and returns both keys.
+ *
+ * @param composePath - Absolute path to docker-compose.db.yml (or similar)
+ * @returns Object with anonKey and serviceKey (empty string if not found)
+ */
+export function extractSupabaseKeys(composePath: string): SupabaseKeys {
+  let content: string;
+  try {
+    content = fs.readFileSync(composePath, "utf8");
+  } catch {
+    return { anonKey: "", serviceKey: "" };
   }
-  return "";
+  return {
+    anonKey: extractFirst(content, ANON_KEY_PATTERNS),
+    serviceKey: extractFirst(content, SERVICE_KEY_PATTERNS),
+  };
 }

--- a/packages/sdk/src/container-utils.ts
+++ b/packages/sdk/src/container-utils.ts
@@ -1,0 +1,41 @@
+/**
+ * Docker container naming utilities.
+ *
+ * Derives the Docker Compose project prefix from project config or project root.
+ * Used by core (for SBT_PREFIX env) and plugins (e.g. log tailing).
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Sanitizes a raw project name into a valid Docker Compose project prefix.
+ * Use when you already have the project name (e.g. from loaded config).
+ */
+export function sanitizeContainerPrefix(projectName: string): string {
+  return (
+    projectName
+      .replace(/[^a-zA-Z0-9-]/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "")
+      .toLowerCase() || "sbt"
+  );
+}
+
+/**
+ * Derives the container prefix from a project root.
+ * Reads supabase-tools.config.json for project.name, or falls back to the
+ * directory basename. Returns a sanitized prefix suitable for Docker.
+ */
+export function deriveContainerPrefix(projectRoot: string): string {
+  let projectName = path.basename(projectRoot);
+  const configPath = path.join(projectRoot, "supabase-tools.config.json");
+  if (fs.existsSync(configPath)) {
+    try {
+      const cfg = JSON.parse(fs.readFileSync(configPath, "utf8"));
+      if (cfg?.project?.name) projectName = cfg.project.name;
+    } catch {
+      /* use fallback */
+    }
+  }
+  return sanitizeContainerPrefix(projectName);
+}

--- a/packages/sdk/src/fs-utils.ts
+++ b/packages/sdk/src/fs-utils.ts
@@ -36,6 +36,25 @@ export function safeName(s: string): string {
 }
 
 /**
+ * Sanitizes a string into a hyphenated slug (e.g. plugin names, directory names).
+ * Keeps alphanumeric and hyphens, collapses runs of hyphens, trims.
+ */
+export function sanitizeSlug(s: string): string {
+  return s
+    .replace(/[^a-zA-Z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+/**
+ * Sanitizes a string for use as an identifier (e.g. Mermaid node IDs).
+ * Keeps alphanumeric and underscores only.
+ */
+export function sanitizeIdentifier(s: string): string {
+  return s.replace(/[^a-zA-Z0-9_]/g, "_");
+}
+
+/**
  * Truncates a filename to a maximum length and appends a short hash to avoid collisions.
  * Keeps extension intact.
  */

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -62,7 +62,16 @@ export {
     readText,
     safeName,
     safeFileName,
+    sanitizeSlug,
+    sanitizeIdentifier,
 } from "./fs-utils.js";
 
 // Compose utilities
-export { extractComposeKey } from "./compose-utils.js";
+export { extractComposeKey, extractSupabaseKeys } from "./compose-utils.js";
+export type { SupabaseKeys } from "./compose-utils.js";
+
+// Container utilities
+export {
+  sanitizeContainerPrefix,
+  deriveContainerPrefix,
+} from "./container-utils.js";

--- a/packages/sdk/tests/compose-utils.test.ts
+++ b/packages/sdk/tests/compose-utils.test.ts
@@ -1,0 +1,98 @@
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { describe, it, expect } from "vitest";
+import { extractComposeKey, extractSupabaseKeys } from "@sbtools/sdk";
+
+function makeTempCompose(content: string): string {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "compose-test-"));
+  const filePath = path.join(tmp, "docker-compose.db.yml");
+  fs.writeFileSync(filePath, content, "utf8");
+  return filePath;
+}
+
+function withTempCompose(content: string, fn: (p: string) => void): void {
+  const filePath = makeTempCompose(content);
+  try {
+    fn(filePath);
+  } finally {
+    fs.rmSync(path.dirname(filePath), { recursive: true });
+  }
+}
+
+describe("extractComposeKey", () => {
+  it("extracts value from first matching pattern", () => {
+    withTempCompose("JWT_SECRET: my-secret-123", (p) => {
+      const result = extractComposeKey(p, [/JWT_SECRET:\s*([^\s]+)/]);
+      expect(result).toBe("my-secret-123");
+    });
+  });
+  it("tries patterns in order, first match wins", () => {
+    withTempCompose("AUTH_JWT_SECRET: fallback-secret", (p) => {
+      const result = extractComposeKey(p, [
+        /JWT_SECRET:\s*([^\s]+)/,
+        /AUTH_JWT_SECRET:\s*([^\s]+)/,
+      ]);
+      expect(result).toBe("fallback-secret");
+    });
+  });
+  it("returns empty string for non-existent file", () => {
+    const result = extractComposeKey("/nonexistent/path/compose.yml", [/KEY:\s*([^\s]+)/]);
+    expect(result).toBe("");
+  });
+  it("returns empty string when no pattern matches", () => {
+    withTempCompose("OTHER: value", (p) => {
+      const result = extractComposeKey(p, [/JWT_SECRET:\s*([^\s]+)/]);
+      expect(result).toBe("");
+    });
+  });
+});
+
+describe("extractSupabaseKeys", () => {
+  it("extracts both anon and service key", () => {
+    withTempCompose(
+      [
+        "SUPABASE_ANON_KEY: eyJanon123",
+        "SUPABASE_SERVICE_ROLE_KEY: eyJservice456",
+      ].join("\n"),
+      (p) => {
+        const { anonKey, serviceKey } = extractSupabaseKeys(p);
+        expect(anonKey).toBe("eyJanon123");
+        expect(serviceKey).toBe("eyJservice456");
+      },
+    );
+  });
+  it("accepts alternative key names", () => {
+    withTempCompose(
+      ["ANON_KEY: anon-key", "SERVICE_KEY: service-key"].join("\n"),
+      (p) => {
+        const { anonKey, serviceKey } = extractSupabaseKeys(p);
+        expect(anonKey).toBe("anon-key");
+        expect(serviceKey).toBe("service-key");
+      },
+    );
+  });
+  it("returns empty strings for non-existent file", () => {
+    const result = extractSupabaseKeys("/nonexistent/docker-compose.db.yml");
+    expect(result).toEqual({ anonKey: "", serviceKey: "" });
+  });
+  it("returns empty for missing keys", () => {
+    withTempCompose("OTHER: value", (p) => {
+      const result = extractSupabaseKeys(p);
+      expect(result).toEqual({ anonKey: "", serviceKey: "" });
+    });
+  });
+  it("trims whitespace from values", () => {
+    withTempCompose(
+      [
+        "SUPABASE_ANON_KEY:  eyJtrimmed  ",
+        "SUPABASE_SERVICE_ROLE_KEY:  eyJalso  ",
+      ].join("\n"),
+      (p) => {
+        const { anonKey, serviceKey } = extractSupabaseKeys(p);
+        expect(anonKey).toBe("eyJtrimmed");
+        expect(serviceKey).toBe("eyJalso");
+      },
+    );
+  });
+});

--- a/packages/sdk/tests/container-utils.test.ts
+++ b/packages/sdk/tests/container-utils.test.ts
@@ -1,0 +1,87 @@
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { describe, it, expect } from "vitest";
+import { sanitizeContainerPrefix, deriveContainerPrefix } from "@sbtools/sdk";
+
+describe("sanitizeContainerPrefix", () => {
+  it("passes through valid names and lowercases", () => {
+    expect(sanitizeContainerPrefix("my-project")).toBe("my-project");
+    expect(sanitizeContainerPrefix("MyProject")).toBe("myproject");
+  });
+  it("replaces invalid chars with hyphen and collapses", () => {
+    expect(sanitizeContainerPrefix("my project!")).toBe("my-project");
+    expect(sanitizeContainerPrefix("a  b---c")).toBe("a-b-c");
+  });
+  it("trims leading and trailing hyphens", () => {
+    expect(sanitizeContainerPrefix("-hello-")).toBe("hello");
+    expect(sanitizeContainerPrefix("--abc--")).toBe("abc");
+  });
+  it("returns 'sbt' fallback for empty result", () => {
+    expect(sanitizeContainerPrefix("")).toBe("sbt");
+    expect(sanitizeContainerPrefix("!!!")).toBe("sbt");
+    expect(sanitizeContainerPrefix("---")).toBe("sbt");
+  });
+});
+
+describe("deriveContainerPrefix", () => {
+  it("falls back to directory basename when no config", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "sbt-test-"));
+    try {
+      const result = deriveContainerPrefix(tmp);
+      expect(result).toBe(sanitizeContainerPrefix(path.basename(tmp)));
+    } finally {
+      fs.rmSync(tmp, { recursive: true });
+    }
+  });
+  it("uses project.name from config when present", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "sbt-test-"));
+    try {
+      fs.writeFileSync(
+        path.join(tmp, "supabase-tools.config.json"),
+        JSON.stringify({ project: { name: "My Awesome Project" } }),
+        "utf8",
+      );
+      expect(deriveContainerPrefix(tmp)).toBe("my-awesome-project");
+    } finally {
+      fs.rmSync(tmp, { recursive: true });
+    }
+  });
+  it("sanitizes config project name", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "sbt-test-"));
+    try {
+      fs.writeFileSync(
+        path.join(tmp, "supabase-tools.config.json"),
+        JSON.stringify({ project: { name: "Project!!!" } }),
+        "utf8",
+      );
+      expect(deriveContainerPrefix(tmp)).toBe("project");
+    } finally {
+      fs.rmSync(tmp, { recursive: true });
+    }
+  });
+  it("falls back to basename when config has no project.name", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "derive-test-"));
+    try {
+      fs.writeFileSync(
+        path.join(tmp, "supabase-tools.config.json"),
+        JSON.stringify({ paths: {} }),
+        "utf8",
+      );
+      const result = deriveContainerPrefix(tmp);
+      expect(result).toBe(sanitizeContainerPrefix(path.basename(tmp)));
+    } finally {
+      fs.rmSync(tmp, { recursive: true });
+    }
+  });
+  it("falls back to basename on invalid config", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "derive-test-"));
+    try {
+      fs.writeFileSync(path.join(tmp, "supabase-tools.config.json"), "not json", "utf8");
+      const result = deriveContainerPrefix(tmp);
+      expect(result).toBe(sanitizeContainerPrefix(path.basename(tmp)));
+    } finally {
+      fs.rmSync(tmp, { recursive: true });
+    }
+  });
+});

--- a/packages/sdk/tests/fs-utils.test.ts
+++ b/packages/sdk/tests/fs-utils.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import {
+  safeName,
+  safeFileName,
+  sanitizeSlug,
+  sanitizeIdentifier,
+} from "@sbtools/sdk";
+
+describe("safeName", () => {
+  it("passes through simple names", () => {
+    expect(safeName("public")).toBe("public");
+  });
+  it("replaces special characters with underscore", () => {
+    expect(safeName("my schema!@#")).toBe("my_schema___");
+  });
+  it("preserves dots and hyphens", () => {
+    expect(safeName("a.b-c")).toBe("a.b-c");
+  });
+});
+
+describe("safeFileName", () => {
+  it("returns short names as-is", () => {
+    expect(safeFileName("test.sql")).toBe("test.sql");
+  });
+  it("truncates long names and adds hash", () => {
+    const long = "a".repeat(200) + ".sql";
+    const result = safeFileName(long, 180);
+    expect(result.length).toBeLessThanOrEqual(180);
+    expect(result.endsWith(".sql")).toBe(true);
+  });
+  it("produces deterministic output", () => {
+    const name = "x".repeat(200) + ".sql";
+    expect(safeFileName(name)).toBe(safeFileName(name));
+  });
+});
+
+describe("sanitizeSlug", () => {
+  it("passes through valid slugs", () => {
+    expect(sanitizeSlug("my-plugin")).toBe("my-plugin");
+    expect(sanitizeSlug("analytics")).toBe("analytics");
+  });
+  it("replaces invalid chars with hyphen and collapses", () => {
+    expect(sanitizeSlug("my plugin")).toBe("my-plugin");
+    expect(sanitizeSlug("a--b")).toBe("a-b");
+  });
+  it("trims leading and trailing hyphens", () => {
+    expect(sanitizeSlug("-hello-")).toBe("hello");
+  });
+  it("replaces underscores with hyphens", () => {
+    expect(sanitizeSlug("plugin_123")).toBe("plugin-123");
+  });
+  it("returns empty for all-invalid input", () => {
+    expect(sanitizeSlug("!!!")).toBe("");
+  });
+});
+
+describe("sanitizeIdentifier", () => {
+  it("passes through valid identifiers", () => {
+    expect(sanitizeIdentifier("user_id")).toBe("user_id");
+    expect(sanitizeIdentifier("Table123")).toBe("Table123");
+  });
+  it("replaces invalid chars with underscore", () => {
+    expect(sanitizeIdentifier("my-table")).toBe("my_table");
+    expect(sanitizeIdentifier("a.b.c")).toBe("a_b_c");
+  });
+  it("handles brackets for Mermaid compatibility", () => {
+    expect(sanitizeIdentifier("public.users")).toBe("public_users");
+  });
+});

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    root: import.meta.dirname,
+    include: ["tests/**/*.test.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Summary

SDK consolidation, docs workflow refactor, and README/documentation clarifications.

## Changes

### SDK
- Add \sanitizeContainerPrefix\, \deriveContainerPrefix\, \xtractSupabaseKeys\, \sanitizeSlug\, \sanitizeIdentifier\
- Add compose-utils, container-utils, fs-utils tests
- Add vitest config

### Core
- Remove \docs\ command from core (now provided by plugin-docs-server)
- \stop\ no longer stops docs compose stack — use \sbt docs stop\ when using plugin-docs-server
- Use SDK \sanitizeContainerPrefix\ and \xtractSupabaseKeys\
- Remove docs-related preflight

### plugin-docs-server
- Replace \start-docs-server\ with \docs\ command
- Add subcommands: swagger, redoc, atlas, schemaspy, all, stop
- Per-subcommand preflight

### Plugins (atlas-html, depgraph, logs, scaffold, typegen, erd)
- Use shared SDK utilities
- Improved error handling (SbtError with tips)
- Remove redundant root index.ts

### Documentation
- Fix extractSupabaseKeys typo in SDK docs
- Clarify start/stop/restart operate on main Supabase stack only
- Document plugin-docs-server requirement for docs commands
- Add Dependencies sections to plugin READMEs

Made with [Cursor](https://cursor.com)