### PR TITLE
Potential fix for code scanning alert no. 3: Replacement of a substring with itself

### DIFF
--- a/packages/plugin-scaffold/src/templates/skill-md.ts
+++ b/packages/plugin-scaffold/src/templates/skill-md.ts
@@ -1,6 +1,6 @@
 export function generateSkillMd(name: string, external: boolean): string {
   const pkgName = `@sbtools/plugin-${name}`;
-  const cmdName = name.replace(/-/g, "-");
+  const cmdName = name;
   const loc = external ? `plugin-${name}/` : `supabase-tools/packages/plugin-${name}/`;
 
   return `# ${pkgName}


### PR DESCRIPTION
Potential fix for [https://github.com/bazokhan/supabase-tools/security/code-scanning/3](https://github.com/bazokhan/supabase-tools/security/code-scanning/3)

In general, to fix a “replacement of a substring with itself” issue, either (a) correct the replacement string or pattern to implement the intended transformation, or (b) if no transformation is needed, remove the redundant `replace` call and use the original string directly. This removes dead code and eliminates confusion.

For this specific case in `packages/plugin-scaffold/src/templates/skill-md.ts`, the minimal, behaviour‑preserving fix is to stop doing an identity replacement and instead just assign `cmdName` directly from `name`. That keeps all generated markdown and CLI examples exactly as before (since `name.replace(/-/g, '-')` was already equal to `name`), while removing the CodeQL‑flagged pattern and clarifying the intent. Concretely, on line 3, change `const cmdName = name.replace(/-/g, "-");` to `const cmdName = name;`. No additional imports or helper methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
